### PR TITLE
Remove exported All var from spin package and move it to example/all/…

### DIFF
--- a/example/all/main.go
+++ b/example/all/main.go
@@ -1,3 +1,4 @@
+//DO NOT EDIT : this file was automatically generated.
 package main
 
 import (
@@ -8,8 +9,10 @@ import (
 	"github.com/gernest/wow/spin"
 )
 
+var all = []spin.Name{spin.Toggle6, spin.BouncingBall, spin.Balloon, spin.Toggle, spin.Toggle12, spin.Dots5, spin.Dots6, spin.Dots7, spin.GrowVertical, spin.Noise, spin.Toggle8, spin.SimpleDots, spin.BoxBounce2, spin.Arc, spin.BouncingBar, spin.Christmas, spin.Squish, spin.Triangle, spin.Arrow3, spin.Hearts, spin.Earth, spin.Dqpb, spin.Line2, spin.SquareCorners, spin.Toggle3, spin.Toggle5, spin.Monkey, spin.Clock, spin.Shark, spin.Weather, spin.Dots2, spin.Dots3, spin.Dots12, spin.CircleHalves, spin.Arrow, spin.Moon, spin.Flip, spin.Hamburger, spin.Bounce, spin.Circle, spin.Toggle9, spin.Toggle13, spin.Toggle10, spin.Runner, spin.Dots9, spin.Line, spin.Star, spin.CircleQuarters, spin.Arrow2, spin.Smiley, spin.Dots, spin.Dots4, spin.Pipe, spin.Balloon2, spin.Dots10, spin.Dots11, spin.SimpleDotsScrolling, spin.BoxBounce, spin.Toggle4, spin.Dots8, spin.Toggle2, spin.Toggle7, spin.Toggle11, spin.Pong, spin.Star2, spin.GrowHorizontal}
+
 func main() {
-	for _, v := range spin.All {
+	for _, v := range all {
 		w := wow.New(os.Stdout, spin.Get(v), " "+v.String())
 		w.Start()
 		time.Sleep(2)

--- a/magefile.go
+++ b/magefile.go
@@ -13,8 +13,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/gernest/wow/spin"
-
 	"github.com/magefile/mage/sh"
 
 	"github.com/magefile/mage/mg"
@@ -227,13 +225,4 @@ func Setup() error {
 		return err
 	}
 	return sh.Run("git", "submodule", "update")
-}
-
-func SpinTable() error {
-	fmt.Println("  Name  | What it looks like ")
-	fmt.Println("--------|---------------------")
-	for _, v := range spin.All {
-		fmt.Printf(" `%v` | ![%s](static/%s.gif)\n", strings.Title(v.String()), v, v)
-	}
-	return nil
 }

--- a/spin/spinners.go
+++ b/spin/spinners.go
@@ -82,8 +82,6 @@ const (
 	Weather
 )
 
-var All = []Name{Star2, GrowHorizontal, Squish, Toggle12, Smiley, Hearts, Dots3, Dots11, Balloon, Clock, Dots4, SquareCorners, CircleHalves, Star, Arc, Toggle13, BoxBounce, Line2, Pipe, Triangle, Shark, Line, Arrow, Earth, Dots5, Toggle11, CircleQuarters, Toggle9, Dots9, Bounce, Toggle2, Toggle7, Arrow3, Moon, Dots6, Christmas, Dots10, Hamburger, BoxBounce2, BouncingBar, Flip, Dots8, Dots12, Noise, Toggle3, Toggle6, Runner, Dqpb, Dots, Toggle4, Monkey, Dots7, SimpleDots, GrowVertical, Circle, Toggle, Toggle5, Arrow2, Dots2, Toggle8, Toggle10, BouncingBall, SimpleDotsScrolling, Pong, Weather, Balloon2}
-
 func (s Name) String() string {
 	switch s {
 	case Arc:


### PR DESCRIPTION
`All` var was exported but used only in example/all/main.go, I think it's better not to hve this exported var. So I moved it to `example/all/main.go`. This file now is also auto-generated by `mage`.