### PR TITLE
add support for options and option to force output

### DIFF
--- a/example/all/main.go
+++ b/example/all/main.go
@@ -13,7 +13,7 @@ var all = []spin.Name{spin.Toggle6, spin.BouncingBall, spin.Balloon, spin.Toggle
 
 func main() {
 	for _, v := range all {
-		w := wow.New(os.Stdout, spin.Get(v), " "+v.String())
+		w := wow.New(os.Stdout, spin.Get(v), " "+v.String(), wow.ForceOutput)
 		w.Start()
 		time.Sleep(2)
 		w.Persist()

--- a/wow.go
+++ b/wow.go
@@ -26,9 +26,16 @@ type Wow struct {
 }
 
 // New creates a new wow instance ready to start spinning.
-func New(o io.Writer, s spin.Spinner, text string) *Wow {
+func New(o io.Writer, s spin.Spinner, text string, options ...func(*Wow)) *Wow {
 	isTerminal := terminal.IsTerminal(int(os.Stdout.Fd()))
-	return &Wow{out: o, s: s, txt: text, isTerminal: isTerminal}
+
+	wow := Wow{out: o, s: s, txt: text, isTerminal: isTerminal}
+
+	for _, option := range options {
+		option(&wow)
+	}
+	
+	return &wow
 }
 
 // Start starts the spinner. The frames are written based on the spinner
@@ -107,4 +114,9 @@ func (w *Wow) PersistWith(s spin.Spinner, text string) {
 	if w.isTerminal {
 		fmt.Fprint(w.out, txt)
 	}
+}
+
+// ForceOutput forces all output even if not not outputting directly to a terminal
+func ForceOutput(w *Wow) {
+	w.isTerminal = true
 }


### PR DESCRIPTION
- Adds option support following [this Dave Cheney post](https://dave.cheney.net/2014/10/17/functional-options-for-friendly-apis) 
- Adds option to handle #10 

Example usage:
```go
package main

import (
	"os"
	"time"

	"github.com/gernest/wow"
	"github.com/gernest/wow/spin"
)

func main() {
	w := wow.New(os.Stdout, spin.Get(spin.Dots), "Such Spins", wow.ForceOutput)
	w.Start()
	time.Sleep(2 * time.Second)
	w.Text("Very emojis").Spinner(spin.Get(spin.Hearts))
	time.Sleep(2 * time.Second)
	w.PersistWith(spin.Spinner{Frames: []string{"👍"}}, " Wow!")
}
```